### PR TITLE
refactor(modularization): Phase 0 foundations (docs-only)

### DIFF
--- a/components/list-builder/common/README.md
+++ b/components/list-builder/common/README.md
@@ -1,0 +1,24 @@
+# Shared Filter Primitives
+
+Purpose: Provide small, composable UI primitives used across all list-builder filters so each domain file can be split into sections/fields without duplicating logic.
+
+## Components (planned)
+- NumericRange (min/max, inclusive/exclusive, empty handling)
+- MultiSelect (searchable, virtualized options, clear-all)
+- TagSelector (chips, any/all modes)
+- ThreeOptionToggle (Yes/No/Any) — unify with existing `components/list-builder/mortgage-filters/components/three-option-toggle.tsx`
+- CheckboxGroup (indeterminate, select-all)
+- DateRange (absolute and relative presets)
+- FieldLabel / HelpText / ErrorText (a11y-friendly)
+
+## API guidelines
+- Controlled inputs with `value` and `onChange` where `onChange` emits a minimal patch `{key?: value}`.
+- No data fetching; UI-only with clear props for labels/options.
+- A11y: label-for, aria-describedby, keyboard nav, focus ring.
+- Performance: memoized render, minimal prop spreads, avoid inline functions on hot paths.
+- Testing: RTL-friendly structure; stable `data-testid` only where necessary.
+
+## Structure
+- Keep each primitive ≤ 150–200 LOC; extract subparts (labels, help, error) when growing.
+- Co-locate minimal CSS (prefer Tailwind) or reuse existing utility classes.
+- Unit test behavior in the consumer packages (Phase 1A) and add targeted unit tests here for tricky logic.

--- a/components/table/README.md
+++ b/components/table/README.md
@@ -1,0 +1,24 @@
+# Table Primitives
+
+Purpose: Provide reusable building blocks for data tables used by Mailing List Manager lists and records.
+
+## Building blocks (planned)
+- DataTable (shell around @tanstack/react-table)
+- ColumnDefs (co-located per table)
+- ColumnVisibility (toggle menu)
+- ColumnFilters (text, select, date)
+- Sorting (single/multi)
+- RowSelection (checkboxes)
+- Pagination (client or server)
+- DensityToggle (compact/comfortable)
+- Toolbar (export, refresh, clear filters)
+
+## Guidelines
+- Keep DataTable generic; pages provide column defs and data source.
+- No app-specific logic; compose features via props and render callbacks.
+- Support controlled state to enable server-driven pagination/sorting later.
+- Keep files ≤ 200 LOC; extract subparts (Toolbar, FilterRow) as needed.
+
+## Testing
+- Unit test column helpers; smoke-test rendering with basic data.
+- Per-table tests live next to the table that consumes these primitives.

--- a/docs/modularization/phase-0.md
+++ b/docs/modularization/phase-0.md
@@ -1,0 +1,29 @@
+# Modularization — Phase 0 (Foundations)
+
+Status: INITIATED
+Branch: `feat/mod-phase-0-foundations`
+
+## Baseline audit
+- Tests: PASS (Mocha harness) — see `tests/` (28 passing)
+- Lint: TBD
+- Typecheck: FAIL (existing project errors; ~96 across 19 files). No changes in Phase 0 will modify TS.
+- Gemini LOC audit (>300 LOC): Completed; see CLI output captured during baseline.
+
+## Scope
+- Add README-only scaffolding:
+  - `components/list-builder/common/` — shared filter primitives
+  - `hooks/filters/` — shared hooks
+  - `components/table/` — table building blocks
+  - `lib/mappers/` — pure data mappers
+  - `lib/errors/` — error normalization
+
+No behavior changes; no TypeScript code introduced in Phase 0.
+
+## Acceptance criteria
+- Directories created with clear conventions and APIs documented.
+- No runtime changes; test suite remains green.
+- Pre/Post Gemini audit available for later phases.
+
+## Next steps
+- Phase 1A: begin extracting List Builder domains into subcomponents that consume these primitives and hooks.
+- Optional: add CI jobs for lint and typecheck (non-blocking until type errors are addressed).

--- a/hooks/filters/README.md
+++ b/hooks/filters/README.md
@@ -1,0 +1,22 @@
+# Shared Filter Hooks
+
+Purpose: Centralize filter state handling across List Builder domains so page/components can compose small, focused units.
+
+## Hooks (planned)
+- useFilterState<T>(initial: T): [state: T, patch: (p: Partial<T>) => void]
+  - Emits minimal patches; merges shallowly; no I/O.
+- useFilterDebounce<T>(value: T, ms: number): T
+  - Debounce noisy inputs before propagating to expensive consumers.
+- useFilterPersistence<T>(key: string, value: T, version?: number): void
+  - Persist to localStorage/sessionStorage; include versioning + safe parse.
+- useCriteriaAdapter<TCriteria>()
+  - Bridges UI state <-> domain criteria (adapts to existing `hooks/use-criterion-update.ts`).
+
+## Integration notes
+- Do not fetch inside hooks; expose pure state + callbacks.
+- Keep types generic; UI layers (components) adapt to domain types (e.g., `MortgageCriteria`).
+- Side-effects (analytics, sync) are opt-in wrappers, not core hook behavior.
+
+## Testing
+- Unit test reducers and edge-cases (empty patch, resets, version bumps).
+- Component tests verify integration within each domain orchestrator (Phase 1A).

--- a/lib/errors/README.md
+++ b/lib/errors/README.md
@@ -1,0 +1,15 @@
+# Error Normalization
+
+Purpose: Provide a consistent error surface across fetch/Supabase/third-party APIs.
+
+## Pattern
+- Define `DomainError` with `code`, `message`, and optional `cause`.
+- Map HTTP/Supabase/SDK errors to `DomainError` in one place.
+- Utilities for `isDomainError`, `toDomainError`.
+
+## Usage
+- API/queries: wrap and rethrow as `DomainError`.
+- UI: render friendly messages; optionally log raw cause in dev.
+
+## Testing
+- Unit tests for mappers: input error -> expected DomainError.

--- a/lib/mappers/README.md
+++ b/lib/mappers/README.md
@@ -1,0 +1,12 @@
+# Mappers
+
+Purpose: Pure functions that convert between external data (API/Supabase) and internal app models.
+
+## Conventions
+- Pure, side-effect free; throw typed errors only (see `lib/errors`).
+- Input/Output types live in `types/`; co-locate zod schemas when added.
+- Keep per-domain files small: `accuzip.mappers.ts`, `mailing-lists.mappers.ts`, etc.
+
+## Testing
+- 100% branch coverage for optional fields and null/undefined handling.
+- Golden tests for sample payloads; no network.


### PR DESCRIPTION
# Modularization — Phase 0 (Foundations)

Status: INITIATED
Branch: `feat/mod-phase-0-foundations`

## Baseline audit
- Tests: PASS (Mocha harness) — see `tests/` (28 passing)
- Lint: TBD
- Typecheck: FAIL (existing project errors; ~96 across 19 files). No changes in Phase 0 will modify TS.
- Gemini LOC audit (>300 LOC): Completed; see CLI output captured during baseline.

## Scope
- Add README-only scaffolding:
  - `components/list-builder/common/` — shared filter primitives
  - `hooks/filters/` — shared hooks
  - `components/table/` — table building blocks
  - `lib/mappers/` — pure data mappers
  - `lib/errors/` — error normalization

No behavior changes; no TypeScript code introduced in Phase 0.

## Acceptance criteria
- Directories created with clear conventions and APIs documented.
- No runtime changes; test suite remains green.
- Pre/Post Gemini audit available for later phases.

## Next steps
- Phase 1A: begin extracting List Builder domains into subcomponents that consume these primitives and hooks.
- Optional: add CI jobs for lint and typecheck (non-blocking until type errors are addressed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added planning docs for reusable Filter UI primitives (ranges, selects, tags, toggles, checkboxes, date ranges) with accessibility and performance guidelines.
  * Introduced Table primitives overview (data table wrapper, columns, visibility, filters, sorting, selection, pagination, density, toolbar) with testing guidance.
  * Published Phase 0 modularization plan outlining scope, acceptance criteria, and next steps; no runtime changes.
  * Documented shared Filter hooks (state, debounce, persistence, criteria adapter) and usage notes.
  * Added Error normalization guidance (standardized domain errors and mapping patterns).
  * Documented data mappers conventions and testing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->