### PR TITLE
feat(payments): production Stripe webhook — idempotent reconcile + webhook_events

### DIFF
--- a/app/api/payments/webhooks/stripe/route.ts
+++ b/app/api/payments/webhooks/stripe/route.ts
@@ -1,25 +1,28 @@
 /**
  * Stripe Webhooks Handler
- * 
- * Processes Stripe webhook events to keep database in sync with Stripe.
- * Handles payment and subscription lifecycle events.
+ *
+ * Verifies and processes Stripe payment_intent events to reconcile order
+ * payment state in the consolidated inline-payment model. The order's
+ * authoritative payment status is set synchronously at authorize/approve;
+ * this webhook is the backstop that re-syncs the `orders` row (by
+ * stripe_payment_intent_id) if an API response was ever lost. It does NOT
+ * advance fulfillment status (order_status) to avoid regressing an order that
+ * has already shipped/completed — it only writes the money facts.
  */
 
-import { NextRequest, NextResponse } from 'next/server';
-import { headers } from 'next/headers';
-import Stripe from 'stripe';
-import { stripe } from '@/lib/payments/stripe-config';
-import { createClient } from '@/utils/supabase/service';
-import { mapStripeStatusToDb } from '@/lib/payments/types';
-import type { PaymentStatus, SubscriptionStatus } from '@/types/supabase-comprehensive';
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { 
-  validateWebhookIp, 
-  checkWebhookRateLimit, 
-  logWebhookSecurity 
-} from '@/lib/webhooks/security';
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import Stripe from 'stripe'
+import { stripe } from '@/lib/payments/stripe-config'
+import { createClient } from '@/utils/supabase/service'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import {
+  validateWebhookIp,
+  checkWebhookRateLimit,
+  logWebhookSecurity,
+} from '@/lib/webhooks/security'
 
-const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET!
 const stripeWebhookIps = [
   '18.245.8.0/26',
   '3.130.192.231/32',
@@ -29,538 +32,157 @@ const stripeWebhookIps = [
   '3.89.151.48/32',
   '54.187.174.169/32',
   '54.187.205.235/32',
-  '54.187.216.72/32'
-];
+  '54.187.216.72/32',
+]
 
 if (!webhookSecret) {
-  throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required');
+  throw new Error('STRIPE_WEBHOOK_SECRET environment variable is required')
 }
 
-// Use Node.js runtime for crypto operations and webhook signature verification
-export const runtime = 'nodejs';
+// Node.js runtime for crypto-based signature verification.
+export const runtime = 'nodejs'
 
 export async function POST(request: NextRequest) {
-  const clientIp = request.headers.get('x-forwarded-for')?.split(',')[0] ||
-                   request.headers.get('x-real-ip') ||
-                   'unknown';
+  const clientIp =
+    request.headers.get('x-forwarded-for')?.split(',')[0] ||
+    request.headers.get('x-real-ip') ||
+    'unknown'
 
   try {
-    // 1. Validate Stripe IP allowlist (in production)
     if (process.env.NODE_ENV === 'production' && !validateWebhookIp(request, stripeWebhookIps)) {
-      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-        valid: false, 
-        error: 'IP not in allowlist' 
-      });
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
+      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: false, error: 'IP not in allowlist' })
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    // 2. Check rate limiting
-    const rateLimitResult = checkWebhookRateLimit(clientIp, 60, 60000); // 60 requests per minute
+    const rateLimitResult = checkWebhookRateLimit(clientIp, 60, 60000)
     if (!rateLimitResult.allowed) {
-      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-        valid: false, 
-        error: 'Rate limit exceeded' 
-      });
+      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: false, error: 'Rate limit exceeded' })
       return NextResponse.json(
         { error: 'Rate limit exceeded' },
-        { 
+        {
           status: 429,
           headers: {
             'X-RateLimit-Remaining': rateLimitResult.remaining.toString(),
-            'X-RateLimit-Reset': new Date(rateLimitResult.resetTime).toISOString()
-          }
+            'X-RateLimit-Reset': new Date(rateLimitResult.resetTime).toISOString(),
+          },
         }
-      );
+      )
     }
 
     if (!stripe) {
-      return NextResponse.json(
-        { error: 'Stripe not configured' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: 'Stripe not configured' }, { status: 500 })
     }
 
-    // 3. Get the raw body for signature verification
-    const body = await request.text();
-    const signature = (await headers()).get('stripe-signature');
-
+    const body = await request.text()
+    const signature = (await headers()).get('stripe-signature')
     if (!signature) {
-      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-        valid: false, 
-        error: 'Missing Stripe signature' 
-      });
-      return NextResponse.json(
-        { error: 'Missing Stripe signature' },
-        { status: 400 }
-      );
+      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: false, error: 'Missing Stripe signature' })
+      return NextResponse.json({ error: 'Missing Stripe signature' }, { status: 400 })
     }
 
-    // 4. Verify webhook signature with enhanced error handling
-    let event: Stripe.Event;
+    let event: Stripe.Event
     try {
-      event = stripe.webhooks.constructEvent(body, signature, webhookSecret);
+      event = stripe.webhooks.constructEvent(body, signature, webhookSecret)
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : 'Unknown signature error';
-      console.error('Webhook signature verification failed:', errorMsg);
-      
-      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-        valid: false, 
-        error: `Invalid signature: ${errorMsg}` 
-      });
-      
-      return NextResponse.json(
-        { error: 'Invalid webhook signature' },
-        { status: 400 }
-      );
+      const errorMsg = error instanceof Error ? error.message : 'Unknown signature error'
+      console.error('Webhook signature verification failed:', errorMsg)
+      logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: false, error: `Invalid signature: ${errorMsg}` })
+      return NextResponse.json({ error: 'Invalid webhook signature' }, { status: 400 })
     }
 
-    // 5. Log successful validation
-    logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-      valid: true 
-    });
+    logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: true })
+    console.log(`Received webhook event: ${event.type} (${event.id})`)
 
-    console.log(`Received webhook event: ${event.type} (${event.id})`);
-
-    // 6. Process the event with idempotency check
-    const processResult = await processWebhookEvent(event);
-    
-    return NextResponse.json({ 
-      received: true, 
-      event_type: event.type,
-      event_id: event.id,
-      processed: processResult 
-    });
-
+    const processed = await processWebhookEvent(event)
+    return NextResponse.json({ received: true, event_type: event.type, event_id: event.id, processed })
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : 'Unknown processing error';
-    console.error('Webhook processing error:', errorMsg);
-    
-    logWebhookSecurity(request, '/api/payments/webhooks/stripe', { 
-      valid: false, 
-      error: `Processing failed: ${errorMsg}` 
-    });
-    
-    return NextResponse.json(
-      { error: 'Webhook processing failed' },
-      { status: 500 }
-    );
+    const errorMsg = error instanceof Error ? error.message : 'Unknown processing error'
+    console.error('Webhook processing error:', errorMsg)
+    logWebhookSecurity(request, '/api/payments/webhooks/stripe', { valid: false, error: `Processing failed: ${errorMsg}` })
+    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 })
   }
 }
 
-/**
- * Process individual webhook events with idempotency
- */
+/** Idempotent dispatch: record the event, process, mark processed. */
 async function processWebhookEvent(event: Stripe.Event): Promise<boolean> {
-  const supabase = createClient();
+  const supabase = createClient()
 
-  // Check if this event has already been processed (idempotency)
   const { data: existingEvent } = await supabase
     .from('webhook_events')
     .select('id, processed_at')
     .eq('stripe_event_id', event.id)
-    .single();
+    .single()
 
   if (existingEvent?.processed_at) {
-    console.log(`Event ${event.id} already processed, skipping`);
-    return true;
+    console.log(`Event ${event.id} already processed, skipping`)
+    return true
   }
-
-  // Record the event processing attempt
   if (!existingEvent) {
-    await supabase
-      .from('webhook_events')
-      .insert({
-        stripe_event_id: event.id,
-        event_type: event.type,
-        processed_at: null,
-        created_at: new Date().toISOString()
-      });
+    await supabase.from('webhook_events').insert({
+      stripe_event_id: event.id,
+      event_type: event.type,
+      created_at: new Date().toISOString(),
+    })
   }
 
   switch (event.type) {
-    // Payment Intent Events
     case 'payment_intent.succeeded':
-      await handlePaymentIntentSucceeded(event.data.object as Stripe.PaymentIntent, supabase);
-      break;
-
+      await handlePaymentIntentSucceeded(event.data.object as Stripe.PaymentIntent, supabase)
+      break
     case 'payment_intent.payment_failed':
-      await handlePaymentIntentFailed(event.data.object as Stripe.PaymentIntent, supabase);
-      break;
-
+      await setOrderPaymentStatus((event.data.object as Stripe.PaymentIntent).id, 'failed', supabase)
+      break
     case 'payment_intent.canceled':
-      await handlePaymentIntentCanceled(event.data.object as Stripe.PaymentIntent, supabase);
-      break;
-
-    // Subscription Events
-    case 'customer.subscription.created':
-      await handleSubscriptionCreated(event.data.object as Stripe.Subscription, supabase);
-      break;
-
-    case 'customer.subscription.updated':
-      await handleSubscriptionUpdated(event.data.object as Stripe.Subscription, supabase);
-      break;
-
-    case 'customer.subscription.deleted':
-      await handleSubscriptionDeleted(event.data.object as Stripe.Subscription, supabase);
-      break;
-
-    // Invoice Events
-    case 'invoice.payment_succeeded':
-      await handleInvoicePaymentSucceeded(event.data.object as Stripe.Invoice, supabase);
-      break;
-
-    case 'invoice.payment_failed':
-      await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice, supabase);
-      break;
-
-    // Customer Events
-    case 'customer.updated':
-      await handleCustomerUpdated(event.data.object as Stripe.Customer, supabase);
-      break;
-
-    // Payment Method Events
-    case 'payment_method.attached':
-      await handlePaymentMethodAttached(event.data.object as Stripe.PaymentMethod, supabase);
-      break;
-
+      await setOrderPaymentStatus((event.data.object as Stripe.PaymentIntent).id, 'canceled', supabase)
+      break
     default:
-      console.log(`Unhandled webhook event type: ${event.type}`);
-      break;
+      console.log(`Unhandled webhook event type: ${event.type}`)
+      break
   }
 
-  // Mark event as successfully processed
   await supabase
     .from('webhook_events')
     .update({ processed_at: new Date().toISOString() })
-    .eq('stripe_event_id', event.id);
+    .eq('stripe_event_id', event.id)
 
-  return true;
+  return true
 }
 
 /**
- * Payment Intent Event Handlers
+ * For manual-capture PIs, payment_intent.succeeded means the charge was
+ * captured — reconcile the order's money facts (payment_status + amount_captured).
+ * Does not touch order_status (fulfillment is driven elsewhere).
  */
 async function handlePaymentIntentSucceeded(
   paymentIntent: Stripe.PaymentIntent,
   supabase: SupabaseClient
 ): Promise<void> {
-  const latestCharge = paymentIntent.latest_charge;
-  const chargeCaptured =
-    typeof latestCharge === 'object' && latestCharge !== null
-      ? latestCharge.captured
-      : false;
-  const status: PaymentStatus = paymentIntent.capture_method === 'manual'
-    ? (chargeCaptured ? 'captured' : 'authorized')
-    : 'captured';
-
-  const updateData: {
-    status: PaymentStatus;
-    payment_method_id: string | null;
-    authorized_at?: string;
-    captured_at?: string;
-  } = {
-    status,
-    payment_method_id: paymentIntent.payment_method as string || null,
-  };
-
-  if (status === 'authorized') {
-    updateData.authorized_at = new Date().toISOString();
-  } else {
-    updateData.captured_at = new Date().toISOString();
-  }
+  const amountCaptured =
+    typeof paymentIntent.amount_received === 'number' ? paymentIntent.amount_received / 100 : null
 
   const { error } = await supabase
-    .from('payment_transactions')
-    .update(updateData)
-    .eq('stripe_payment_intent_id', paymentIntent.id);
+    .from('orders')
+    .update({ payment_status: 'captured', amount_captured: amountCaptured })
+    .eq('stripe_payment_intent_id', paymentIntent.id)
+    .neq('payment_status', 'captured')
 
-  if (error) {
-    console.error('Failed to update payment transaction:', error);
-  }
+  if (error) console.error('Webhook: failed to reconcile captured order:', error)
 }
 
-async function handlePaymentIntentFailed(
-  paymentIntent: Stripe.PaymentIntent,
+/** Mark the order's payment_status for failed/canceled PIs. */
+async function setOrderPaymentStatus(
+  paymentIntentId: string,
+  status: 'failed' | 'canceled',
   supabase: SupabaseClient
 ): Promise<void> {
   const { error } = await supabase
-    .from('payment_transactions')
-    .update({
-      status: 'failed' as PaymentStatus,
-      failure_reason: paymentIntent.last_payment_error?.message || 'Payment failed',
-    })
-    .eq('stripe_payment_intent_id', paymentIntent.id);
+    .from('orders')
+    .update({ payment_status: status })
+    .eq('stripe_payment_intent_id', paymentIntentId)
 
-  if (error) {
-    console.error('Failed to update failed payment:', error);
-  }
+  if (error) console.error(`Webhook: failed to set order payment_status=${status}:`, error)
 }
 
-async function handlePaymentIntentCanceled(
-  paymentIntent: Stripe.PaymentIntent,
-  supabase: SupabaseClient
-): Promise<void> {
-  const { error } = await supabase
-    .from('payment_transactions')
-    .update({
-      status: 'failed' as PaymentStatus,
-      failure_reason: 'Payment canceled',
-    })
-    .eq('stripe_payment_intent_id', paymentIntent.id);
-
-  if (error) {
-    console.error('Failed to update canceled payment:', error);
-  }
-}
-
-/**
- * Subscription Event Handlers
- */
-async function handleSubscriptionCreated(
-  subscription: Stripe.Subscription,
-  supabase: SupabaseClient
-): Promise<void> {
-  const userId = subscription.metadata.userId;
-  const teamId = subscription.metadata.teamId;
-  const plan = subscription.metadata.plan;
-
-  if (!userId && !teamId) {
-    console.error('Subscription webhook missing user/team ID:', subscription.id);
-    return;
-  }
-
-  const status = mapStripeStatusToDb(subscription.status);
-
-  if (teamId) {
-    const { error } = await supabase
-      .from('teams')
-      .update({
-        stripe_subscription_id: subscription.id,
-        plan: plan,
-        // Note: teams table doesn't have a subscription_status field in the schema
-      })
-      .eq('id', teamId);
-
-    if (error) {
-      console.error('Failed to update team subscription:', error);
-    }
-  } else {
-    const { error } = await supabase
-      .from('user_profiles')
-      .update({
-        stripe_subscription_id: subscription.id,
-        subscription_plan: plan,
-        subscription_status: status,
-      })
-      .eq('user_id', userId);
-
-    if (error) {
-      console.error('Failed to update user subscription:', error);
-    }
-  }
-}
-
-async function handleSubscriptionUpdated(
-  subscription: Stripe.Subscription,
-  supabase: SupabaseClient
-): Promise<void> {
-  const userId = subscription.metadata.userId;
-  const teamId = subscription.metadata.teamId;
-  const plan = subscription.metadata.plan;
-  const status = mapStripeStatusToDb(subscription.status);
-
-  if (teamId) {
-    const updateData: { plan: string } = { plan };
-    
-    const { error } = await supabase
-      .from('teams')
-      .update(updateData)
-      .eq('stripe_subscription_id', subscription.id);
-
-    if (error) {
-      console.error('Failed to update team subscription:', error);
-    }
-  } else if (userId) {
-    const { error } = await supabase
-      .from('user_profiles')
-      .update({
-        subscription_plan: plan,
-        subscription_status: status,
-      })
-      .eq('stripe_subscription_id', subscription.id);
-
-    if (error) {
-      console.error('Failed to update user subscription:', error);
-    }
-  }
-}
-
-async function handleSubscriptionDeleted(
-  subscription: Stripe.Subscription,
-  supabase: SupabaseClient
-): Promise<void> {
-  const userId = subscription.metadata.userId;
-  const teamId = subscription.metadata.teamId;
-
-  if (teamId) {
-    const { error } = await supabase
-      .from('teams')
-      .update({
-        stripe_subscription_id: null,
-        plan: 'team', // Default team plan
-      })
-      .eq('stripe_subscription_id', subscription.id);
-
-    if (error) {
-      console.error('Failed to update team after subscription deletion:', error);
-    }
-  } else if (userId) {
-    const { error } = await supabase
-      .from('user_profiles')
-      .update({
-        stripe_subscription_id: null,
-        subscription_plan: 'free',
-        subscription_status: 'cancelled',
-      })
-      .eq('stripe_subscription_id', subscription.id);
-
-    if (error) {
-      console.error('Failed to update user after subscription deletion:', error);
-    }
-  }
-}
-
-/**
- * Invoice Event Handlers
- */
-async function handleInvoicePaymentSucceeded(
-  invoice: Stripe.Invoice,
-  supabase: SupabaseClient
-): Promise<void> {
-  const subscriptionRef = invoice.parent?.subscription_details?.subscription;
-  const subscriptionId =
-    typeof subscriptionRef === 'string' ? subscriptionRef : subscriptionRef?.id;
-
-  if (subscriptionId) {
-    // Log successful payment for analytics
-    const { error } = await supabase
-      .from('user_analytics')
-      .insert({
-        user_id: invoice.metadata?.userId || null,
-        event_type: 'invoice_paid',
-        metadata: {
-          invoice_id: invoice.id,
-          subscription_id: subscriptionId,
-          amount: invoice.amount_paid / 100,
-          currency: invoice.currency,
-        },
-      });
-
-    if (error) {
-      console.error('Failed to log invoice payment:', error);
-    }
-  }
-}
-
-async function handleInvoicePaymentFailed(
-  invoice: Stripe.Invoice,
-  supabase: SupabaseClient
-): Promise<void> {
-  const subscriptionRef = invoice.parent?.subscription_details?.subscription;
-  const subscriptionId =
-    typeof subscriptionRef === 'string' ? subscriptionRef : subscriptionRef?.id;
-
-  if (subscriptionId) {
-    // Update subscription status to past_due
-    const { error } = await supabase
-      .from('user_profiles')
-      .update({
-        subscription_status: 'past_due' as SubscriptionStatus,
-      })
-      .eq('stripe_subscription_id', subscriptionId);
-
-    if (error) {
-      console.error('Failed to update subscription to past_due:', error);
-    }
-
-    // Log failed payment for analytics
-    const { error: analyticsError } = await supabase
-      .from('user_analytics')
-      .insert({
-        user_id: invoice.metadata?.userId || null,
-        event_type: 'invoice_payment_failed',
-        metadata: {
-          invoice_id: invoice.id,
-          subscription_id: subscriptionId,
-          amount: invoice.amount_due / 100,
-          currency: invoice.currency,
-          failure_reason: invoice.last_finalization_error?.message || 'Payment failed',
-        },
-      });
-
-    if (analyticsError) {
-      console.error('Failed to log invoice payment failure:', analyticsError);
-    }
-  }
-}
-
-/**
- * Customer Event Handlers
- */
-async function handleCustomerUpdated(
-  customer: Stripe.Customer,
-  supabase: SupabaseClient
-): Promise<void> {
-  // Update customer information in profiles
-  const updateData: { full_name?: string } = {};
-  
-  if (customer.name) {
-    updateData.full_name = customer.name;
-  }
-
-  if (Object.keys(updateData).length > 0) {
-    const { error } = await supabase
-      .from('user_profiles')
-      .update(updateData)
-      .eq('stripe_customer_id', customer.id);
-
-    if (error) {
-      console.error('Failed to update customer information:', error);
-    }
-  }
-}
-
-/**
- * Payment Method Event Handlers
- */
-async function handlePaymentMethodAttached(
-  paymentMethod: Stripe.PaymentMethod,
-  supabase: SupabaseClient
-): Promise<void> {
-  // Log payment method attachment for analytics
-  const { error } = await supabase
-    .from('user_analytics')
-    .insert({
-      user_id: null, // We don't have direct user mapping here
-      event_type: 'payment_method_attached',
-      metadata: {
-        payment_method_id: paymentMethod.id,
-        payment_method_type: paymentMethod.type,
-        customer_id: paymentMethod.customer,
-      },
-    });
-
-  if (error) {
-    console.error('Failed to log payment method attachment:', error);
-  }
-}
-
-export async function GET(request: NextRequest) {
-  return NextResponse.json(
-    { error: 'Method not allowed' },
-    { status: 405 }
-  );
+export async function GET() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 })
 }

--- a/supabase/migrations/20260613100000_webhook_events.sql
+++ b/supabase/migrations/20260613100000_webhook_events.sql
@@ -1,0 +1,22 @@
+-- Idempotency store for Stripe webhook processing (consolidated model). The
+-- webhook handler records each Stripe event id and marks it processed, so
+-- retried deliveries become no-ops. Written only by the service role (which
+-- bypasses RLS). Additive + idempotent.
+
+begin;
+
+create table if not exists public.webhook_events (
+  id uuid primary key default gen_random_uuid(),
+  stripe_event_id text not null unique,
+  event_type text not null,
+  processed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_webhook_events_stripe_id on public.webhook_events (stripe_event_id);
+
+alter table public.webhook_events enable row level security;
+-- No public policies: only the service role (RLS-bypassing) reads/writes this
+-- internal log, so RLS-on with no policy = locked to service role.
+
+commit;


### PR DESCRIPTION
## Summary
Finishes the Stripe webhook backstop for the consolidated inline-payment model, and adds its idempotency store. Pairs with the Vercel `STRIPE_WEBHOOK_SECRET` now set to the real endpoint secret (endpoint `we_1Ti3evE4iljtkRl82VavAMRD` → https://app.yellowlettershop.com/api/payments/webhooks/stripe).

## Changes
- **`app/api/payments/webhooks/stripe/route.ts`** — rewrite: keep IP allowlist + rate limit + `constructEvent` signature verification; add `webhook_events` idempotency (record event id, skip if already processed); handle only `payment_intent.succeeded` / `payment_failed` / `canceled` — reconcile `orders` by `stripe_payment_intent_id` (`payment_status` + `amount_captured`), never regressing fulfillment. Removed dead subscription/invoice/customer handlers.
- **`supabase/migrations/20260613100000_webhook_events.sql`** — service-role-only idempotency store (RLS on, no public policy), unique `stripe_event_id` + index. **Applied to production DB2** and verified (RLS on, unique constraint + 3 indexes).

## Verification
- `npm run typecheck:full` → 0 errors
- `npm test` → 167 passing
- Migration applied + structure/RLS/constraint verified on DB2

🤖 Generated with [Claude Code](https://claude.com/claude-code)