### PR TITLE
Release: develop → main (postage areas + designer chrome polish)

### DIFF
--- a/.claude/plans/feature-designer-postage-areas.md
+++ b/.claude/plans/feature-designer-postage-areas.md
@@ -1,0 +1,92 @@
+# Plan — Designer Postage Areas (Stamp & Indicia)
+
+**Type:** feature · **Subject:** designer-postage-areas · **Branch:** `feature/designer-postage-areas` (off `main` @ 32d9f8b, which includes the merged designer UI enhancement).
+**Isolation:** dedicated worktree `../yls.worktrees/feature-designer-postage-areas`.
+
+## Goal
+
+Replace the fixed print-spec **Address Area** overlay with two **movable, compliance-critical design
+elements** — a **Stamp Area** box and an **Indicia Area** box — that the user can place anywhere,
+add from the Module menu, and only delete behind a confirmation. Builds on the merged design system
+(`components/designer/ui/` tokens + primitives, the Module menu, inspector, canvas).
+
+## Why (owner rationale)
+
+Stamp and Indicia areas are postal/mailing-compliance elements: the piece needs a correctly placed
+postage area, and the method dictates which (physical **stamp** vs printed **indicia** permit
+imprint — hence two different sizes). Losing or obstructing one is a silent, expensive failure at
+print/USPS. The Address Area as a free box is redundant — recipient addresses come from the mailing
+list / merge fields.
+
+## Requirements (all owner-confirmed)
+
+1. **Remove the Address Area** box entirely from the designer (drop the `address` print zone / any
+   placeable address box).
+2. **Stamp Area** and **Indicia Area** are real design elements (separate, different default sizes),
+   **freely movable** (drag anywhere).
+3. **Module-menu entries**: add a Stamp Area module and an Indicia Area module so users can add one
+   if the piece doesn't already have it.
+4. **Guarded delete**: deleting either triggers a confirmation dialog requiring explicit approval
+   ("You're about to remove the Stamp/Indicia Area…"). Reuse a shared confirm-dialog pattern (like
+   the contact-card last-card guard).
+5. **Singleton + mutually exclusive** (value-add 1): at most one Stamp and one Indicia; and a piece
+   uses stamp **OR** indicia, not both — once one exists, the Module menu hides/disables the others
+   (or warns). No duplicate.
+6. **Locked by default** (value-add 4): new Stamp/Indicia elements start `locked` so they aren't
+   nudged accidentally (existing lock toggle still lets the user move them deliberately).
+7. **Clear on-canvas labels** (value-add 5): the boxes render labelled "STAMP" / "INDICIA".
+8. **Keep-clear / no-overlay** (owner addition): Stamp and Indicia are **exclusive zones** — no other
+   element may be placed or dragged on top of them. Reject/block any drop or move that would
+   intersect a stamp/indicia box (and prevent dropping new modules onto them).
+
+## Explicitly out of scope (owner declined)
+
+- USPS clearance-rule preflight validation (value-add 2) — not now.
+- Snap-to-USPS-position affordance (value-add 3) — not now.
+
+## Constraints
+
+- **UI-only — no DB schema changes / no migrations** (the other session's `/goal` shares the local
+  Supabase DB). If something seems to need a schema change, STOP and ask.
+- Stay in this worktree; dev server on a **free, non-3010 port**; never touch the main `yls/` tree.
+- All source files **≤350 LOC**; TypeScript strict, no `any`; reuse existing patterns + the merged
+  `components/designer/ui/` design system. No FPD.
+- Invoke **frontend-design** before UI work. Verify in **chrome-devtools** (never Playwright), both
+  themes. Leave the browser open.
+
+## Likely-affected code (verify before editing)
+
+- `components/designer/mail-spec.ts` — print zones incl. `address`/`indicia` SpecRects (drop address;
+  decide whether stamp/indicia remain as guides or become element-only).
+- `components/designer/canvas/print-overlay.tsx` — renders address/indicia overlay labels.
+- `components/designer/module-definitions.ts` + `modules-panel.tsx` — add Stamp/Indicia modules
+  (incl. singleton/mutex availability logic).
+- `components/designer/canvas/canvas-area.tsx` — drag/drop + move; add keep-clear overlap rejection
+  and the guarded-delete hook; render labels; lock-by-default on create.
+- `components/designer/canvas/render-element.tsx` + `types/designer.ts` — new element type(s) for
+  stamp/indicia (or a `postage` element with a `kind`).
+- A shared confirm dialog component for guarded delete.
+- Pure overlap/intersection math → its own module + co-located mocha tests (`tests/designer/`).
+
+## Phases (each ends with a checkpoint commit; gates: typecheck:ui 0, per-file eslint 0, mocha pass)
+
+- **P1 — Model + remove Address.** Add postage element type(s) (stamp/indicia, default sizes,
+  `locked` default, label); drop the Address Area zone/box. Pure helpers (overlap test, singleton/
+  mutex availability) with mocha tests.
+- **P2 — Module menu.** Stamp Area + Indicia Area module entries with singleton + mutual-exclusion
+  availability; add-to-canvas wiring.
+- **P3 — Canvas behavior.** Keep-clear overlap rejection on drop + move; on-canvas STAMP/INDICIA
+  labels; locked-by-default respected.
+- **P4 — Guarded delete.** Shared confirm dialog; deletion of stamp/indicia requires approval.
+- **P5 — Polish + verification.** Both-theme CDT pass; build exit 0; LOC ≤350; report.
+
+## Verification
+
+Per phase: chrome-devtools both themes (place, move, overlap-reject, delete-guard, module
+availability). Pure math (overlap, singleton/mutex) → mocha. `npm run build` exit 0 at the end.
+
+## Open questions for the build session to resolve early
+
+- Do Stamp/Indicia remain represented in `mail-spec` as default placement hints, or become purely
+  user-placed elements? (Default placement on add is fine; they're then movable.)
+- One element type with `kind: 'stamp' | 'indicia'` vs two types — pick the smaller, clearer model.

--- a/app/design/customize/page.tsx
+++ b/app/design/customize/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { User } from "@supabase/supabase-js"
-import { CheckCircle, Loader2 } from "lucide-react"
+import { Loader2 } from "lucide-react"
 import { CanvasArea } from "@/components/designer/canvas-area"
 import { DesignerHeader } from "@/components/designer/designer-header"
 import { DesignerWorkspaceSidebar } from "@/components/designer/designer-workspace-sidebar"
@@ -218,24 +218,15 @@ export default function DesignCustomizerPage() {
         onNext={continueToOrder}
         onToggleOrientation={() => doc.commitDocument({ ...documentState, orientation: documentState.orientation === "portrait" ? "landscape" : "portrait" })}
         onTemplateChange={doc.handleTemplateChange}
-        onCycleTemplate={() => {
-          const index = DESIGN_TEMPLATES.findIndex((template) => template.id === documentState.templateId)
-          doc.handleTemplateChange(DESIGN_TEMPLATES[(index + 1) % DESIGN_TEMPLATES.length].id)
-        }}
         onFormatChange={doc.setFormat}
         canUndo={doc.historyIndex > 0}
         canRedo={doc.historyIndex < doc.history.length - 1}
+        orientation={documentState.orientation}
         templateId={documentState.templateId}
         formatId={doc.formatId}
         templates={templateOptions}
+        savedLabel={autosave.label}
       />
-      <div className="flex h-9 items-center gap-2 border-b border-gray-200 bg-white px-4 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300">
-        <CheckCircle className="h-4 w-4 text-yellow-500" />
-        <span>{documentState.templateName}</span>
-        <span className="text-gray-400">/</span>
-        <span className="capitalize">{documentState.orientation}</span>
-        <span className="ml-auto">{autosave.label}</span>
-      </div>
       <main className="flex flex-1 overflow-hidden">
         <DesignerWorkspaceSidebar
           activePanel={activePanel}

--- a/app/design/customize/page.tsx
+++ b/app/design/customize/page.tsx
@@ -10,6 +10,7 @@ import { DesignerWorkspaceSidebar } from "@/components/designer/designer-workspa
 import { HelpButton } from "@/components/designer/help-button"
 import { PagesPanel } from "@/components/designer/pages-panel"
 import { PreviewModal } from "@/components/designer/preview-modal"
+import { ConfirmDialog } from "@/components/designer/ui/confirm-dialog"
 import { DESIGN_TEMPLATES, DESIGNER_STORAGE_KEY, createDesignerDocument } from "@/components/designer/designer-templates"
 import { specRectsPx, withFormatId } from "@/components/designer/mail-spec"
 import { createClient } from "@/utils/supabase/client"
@@ -50,6 +51,7 @@ export default function DesignCustomizerPage() {
   const [activePage, setActivePage] = useState<DesignerPage>("front")
   const [isPreviewOpen, setIsPreviewOpen] = useState(false)
   const [imageReplaceTarget, setImageReplaceTarget] = useState<string | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null)
   const router = useRouter()
   const fonts = useDesignerFonts()
   const designerImages = useDesignerImages(Boolean(user))
@@ -159,10 +161,21 @@ export default function DesignCustomizerPage() {
     saveDesignRef.current = saveDesign
   }, [saveDesign])
 
+  // Guarded delete: postage (stamp/indicia) areas require explicit confirmation;
+  // everything else deletes immediately. Routes every delete entry point.
+  const requestDeleteElement = useCallback(
+    (id: string) => {
+      const el = activeElements.find((element) => element.id === id)
+      if (el?.type === "postage") setPendingDelete(id)
+      else doc.deleteElement(id)
+    },
+    [activeElements, doc],
+  )
+
   useDesignerShortcuts({
     selectedElement,
     onClearSelection: () => setSelectedElement(null),
-    onDelete: doc.deleteElement,
+    onDelete: requestDeleteElement,
     onDuplicate: doc.duplicateElement,
     onUndo: doc.handleUndo,
     onRedo: doc.handleRedo,
@@ -249,7 +262,7 @@ export default function DesignCustomizerPage() {
           onToggleHidden={(id) => doc.updateElement(id, { hidden: !activeElements.find((element) => element.id === id)?.hidden })}
           onToggleLocked={(id) => doc.updateElement(id, { locked: !activeElements.find((element) => element.id === id)?.locked })}
           onDuplicate={doc.duplicateElement}
-          onDelete={doc.deleteElement}
+          onDelete={requestDeleteElement}
           onReplaceImageRequest={handleReplaceImageRequest}
           activePage={activePage}
           pageBackground={activeBackground}
@@ -271,7 +284,7 @@ export default function DesignCustomizerPage() {
           pan={pan}
           onPanChange={setPan}
           onUpdateElement={doc.updateElement}
-          onDeleteElement={doc.deleteElement}
+          onDeleteElement={requestDeleteElement}
           onDuplicateElement={doc.duplicateElement}
           onToggleLock={(id) => doc.updateElement(id, { locked: !activeElements.find((element) => element.id === id)?.locked })}
           onDropModule={doc.addElement}
@@ -286,6 +299,18 @@ export default function DesignCustomizerPage() {
         </div>
       </main>
       {isPreviewOpen && <PreviewModal documentState={documentState} canvasSize={canvasSize} onClose={() => setIsPreviewOpen(false)} />}
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Remove this postage area?"
+        description="Stamp and Indicia areas are postal-compliance elements. Removing this may affect how your mailpiece is processed — you can re-add it from the Postage tab."
+        confirmLabel="Remove"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) doc.deleteElement(pendingDelete)
+          setPendingDelete(null)
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
       <HelpButton />
     </div>
   )

--- a/components/designer/canvas/canvas-area.tsx
+++ b/components/designer/canvas/canvas-area.tsx
@@ -13,6 +13,7 @@ import { CanvasEmptyState } from "@/components/designer/canvas/canvas-empty-stat
 import { PrintOverlay } from "@/components/designer/canvas/print-overlay"
 import { PageBackgroundLayer } from "@/components/designer/page-background-layer"
 import { dropPointToCanvas, readDragPayload } from "@/components/designer/dnd"
+import { isPostageType, rectsOverlap, violatesKeepClear } from "@/components/designer/postage"
 import type { SpecRects } from "@/components/designer/mail-spec"
 import type { CanvasSize, DesignElement, DesignerImageAsset, DesignerMode, PageBackground } from "@/types/designer"
 
@@ -111,6 +112,9 @@ export function CanvasArea({
         const rect = viewportRef.current?.getBoundingClientRect()
         if (!payload || !rect) return
         const position = dropPointToCanvas(event, rect, currentPan, canvasScale)
+        // Keep-clear: don't drop new content onto a postage (stamp/indicia) box.
+        const dropPoint = { x: position.x, y: position.y, width: 1, height: 1 }
+        if (elements.some((el) => isPostageType(el.type) && rectsOverlap(dropPoint, el))) return
         if (payload.kind === "module") onDropModule(payload.moduleId, position)
         else onDropAsset(payload.asset, position)
       }}
@@ -143,14 +147,18 @@ export function CanvasArea({
                 onDrag={(event, data) => setActiveGuides(computeSnap(element, data.x, data.y, elements, canvasSize).guides)}
                 onDragStop={(event, data) => {
                   setActiveGuides([])
-                  onUpdateElement(element.id, snapPosition(element, data.x, data.y, elements, canvasSize))
+                  const snapped = snapPosition(element, data.x, data.y, elements, canvasSize)
+                  // Keep-clear: reject (snap back) if the move would overlap a postage box.
+                  const candidate = { x: snapped.x, y: snapped.y, width: element.width, height: element.height }
+                  if (violatesKeepClear(element, candidate, elements)) return
+                  onUpdateElement(element.id, snapped)
                 }}
                 onResizeStop={(event, direction, ref, delta, position) => {
-                  onUpdateElement(element.id, {
-                    width: Number.parseInt(ref.style.width, 10),
-                    height: Number.parseInt(ref.style.height, 10),
-                    ...position,
-                  })
+                  const width = Number.parseInt(ref.style.width, 10)
+                  const height = Number.parseInt(ref.style.height, 10)
+                  const candidate = { x: position.x, y: position.y, width, height }
+                  if (violatesKeepClear(element, candidate, elements)) return
+                  onUpdateElement(element.id, { width, height, ...position })
                 }}
                 onClick={(event: React.MouseEvent<HTMLElement>) => {
                   event.stopPropagation()

--- a/components/designer/canvas/print-overlay.tsx
+++ b/components/designer/canvas/print-overlay.tsx
@@ -25,8 +25,6 @@ export function PrintOverlay({ specRects }: { specRects?: SpecRects }) {
       {box(specRects.bleed, "border border-dashed border-red-500/70")}
       {box(specRects.trim, "border border-gray-400")}
       {box(specRects.safe, "border border-dashed border-emerald-500/70")}
-      {box(specRects.address, "border border-blue-500/70 bg-blue-500/5", "Address")}
-      {box(specRects.indicia, "border border-amber-500/70 bg-amber-500/5", "Indicia")}
     </div>
   )
 }

--- a/components/designer/canvas/render-element.tsx
+++ b/components/designer/canvas/render-element.tsx
@@ -2,6 +2,7 @@
 
 import { getFontFamily, type DesignerFont } from "@/components/designer/designer-fonts"
 import { QrRenderer } from "@/components/designer/qr-renderer"
+import { POSTAGE_DEFAULTS } from "@/components/designer/postage"
 import type { DesignElement } from "@/types/designer"
 
 // Moved verbatim from canvas-area (Phase 2 — behavior-preserving split).
@@ -91,6 +92,14 @@ export function RenderElement({
   if (element.type === "qr") {
     return (
       <QrRenderer value={element.value} foreground={element.foreground} background={element.background} alt={element.name} />
+    )
+  }
+
+  if (element.type === "postage") {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-sm border-2 border-dashed border-amber-500/70 bg-amber-500/10 text-center text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+        {POSTAGE_DEFAULTS[element.kind].label}
+      </div>
     )
   }
 

--- a/components/designer/designer-header.tsx
+++ b/components/designer/designer-header.tsx
@@ -1,9 +1,11 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { Save, Undo, Redo, Eye, LayoutPanelLeft, Replace } from "lucide-react"
+import { Eye, Redo, RectangleHorizontal, RectangleVertical, Save, Undo } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { MAIL_FORMATS, type MailFormatId } from "@/components/designer/mail-spec"
+import type { DesignerOrientation } from "@/types/designer"
 
 interface DesignerHeaderProps {
   onUndo: () => void
@@ -13,13 +15,14 @@ interface DesignerHeaderProps {
   onNext: () => void
   onToggleOrientation: () => void
   onTemplateChange: (templateId: string) => void
-  onCycleTemplate: () => void
   onFormatChange: (formatId: MailFormatId) => void
   canUndo: boolean
   canRedo: boolean
+  orientation: DesignerOrientation
   templateId: string
   formatId: MailFormatId
   templates: { id: string; name: string }[]
+  savedLabel: string
 }
 
 export function DesignerHeader({
@@ -30,55 +33,56 @@ export function DesignerHeader({
   onNext,
   onToggleOrientation,
   onTemplateChange,
-  onCycleTemplate,
   onFormatChange,
   canUndo,
   canRedo,
+  orientation,
   templateId,
   formatId,
   templates,
+  savedLabel,
 }: DesignerHeaderProps) {
+  const isPortrait = orientation === "portrait"
   return (
-    <TooltipProvider>
-      <header className="flex items-center justify-between h-16 px-4 bg-card border-b border-border shrink-0">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <select
-              value={templateId}
-              onChange={(event) => onTemplateChange(event.target.value)}
-              className="h-9 rounded-md border border-input bg-transparent px-2 text-sm font-semibold text-foreground"
-              aria-label="Design template"
-            >
+    <TooltipProvider delayDuration={300}>
+      <header className="flex h-16 shrink-0 items-center justify-between border-b border-border bg-card px-4">
+        {/* Left: what you're editing — template, size, orientation, history */}
+        <div className="flex items-center gap-3">
+          <Select value={templateId} onValueChange={onTemplateChange}>
+            <SelectTrigger aria-label="Design template" className="h-9 w-[190px] text-sm font-medium">
+              <SelectValue placeholder="Template" />
+            </SelectTrigger>
+            <SelectContent>
               {templates.map((template) => (
-                <option key={template.id} value={template.id}>
+                <SelectItem key={template.id} value={template.id}>
                   {template.name}
-                </option>
+                </SelectItem>
               ))}
-            </select>
-          </div>
-          <div className="flex items-center gap-2">
-            <select
-              value={formatId}
-              onChange={(event) => onFormatChange(event.target.value as MailFormatId)}
-              className="h-9 rounded-md border border-input bg-transparent px-2 text-sm font-semibold text-foreground"
-              aria-label="Mail piece size"
-            >
+            </SelectContent>
+          </Select>
+          <Select value={formatId} onValueChange={(value) => onFormatChange(value as MailFormatId)}>
+            <SelectTrigger aria-label="Mail piece size" className="h-9 w-[150px] text-sm font-medium">
+              <SelectValue placeholder="Size" />
+            </SelectTrigger>
+            <SelectContent>
               {Object.values(MAIL_FORMATS).map((format) => (
-                <option key={format.id} value={format.id}>
+                <SelectItem key={format.id} value={format.id}>
                   {format.label}
-                </option>
+                </SelectItem>
               ))}
-            </select>
-          </div>
-          <div className="h-6 w-px bg-border" />
-          <div className="flex items-center gap-2">
+            </SelectContent>
+          </Select>
+
+          <div className="mx-1 h-6 w-px bg-border" />
+
+          <div className="flex items-center gap-1">
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon" onClick={onSave} aria-label="Save design">
                   <Save className="h-5 w-5" />
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Save Project</TooltipContent>
+              <TooltipContent>Save project</TooltipContent>
             </Tooltip>
             <Tooltip>
               <TooltipTrigger asChild>
@@ -96,20 +100,31 @@ export function DesignerHeader({
               </TooltipTrigger>
               <TooltipContent>Redo (Ctrl+Y)</TooltipContent>
             </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onToggleOrientation}
+                  aria-label={`Orientation: ${orientation}. Switch to ${isPortrait ? "landscape" : "portrait"}.`}
+                >
+                  {isPortrait ? <RectangleVertical className="h-5 w-5" /> : <RectangleHorizontal className="h-5 w-5" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{isPortrait ? "Portrait — switch to landscape" : "Landscape — switch to portrait"}</TooltipContent>
+            </Tooltip>
           </div>
         </div>
 
+        {/* Right: save status, then where you're going — proof, then order */}
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" className="hidden md:inline-flex bg-transparent" onClick={onToggleOrientation}>
-            <LayoutPanelLeft className="h-4 w-4 mr-2" />
-            Change Orientation
-          </Button>
-          <Button variant="outline" size="sm" className="hidden md:inline-flex bg-transparent" onClick={onCycleTemplate}>
-            <Replace className="h-4 w-4 mr-2" />
-            Change Template
-          </Button>
+          {savedLabel ? (
+            <span className="mr-1 hidden text-xs font-medium text-muted-foreground sm:inline" aria-live="polite">
+              {savedLabel}
+            </span>
+          ) : null}
           <Button variant="outline" size="sm" onClick={onPreview}>
-            <Eye className="h-4 w-4 mr-2" />
+            <Eye className="mr-2 h-4 w-4" />
             Preview
           </Button>
           <Button size="sm" variant="brand" onClick={onNext}>

--- a/components/designer/designer-workspace-sidebar.tsx
+++ b/components/designer/designer-workspace-sidebar.tsx
@@ -83,6 +83,7 @@ export function DesignerWorkspaceSidebar(props: DesignerWorkspaceSidebarProps) {
         {props.activePanel === "modules" && (
           <ModulesPanel
             activeTool={props.activeTool}
+            elements={props.elements}
             onSelectTool={props.onToolChange}
             onAddModule={props.onAddModule}
             savedImages={props.savedImages}

--- a/components/designer/designer-workspace-sidebar.tsx
+++ b/components/designer/designer-workspace-sidebar.tsx
@@ -68,7 +68,7 @@ export function DesignerWorkspaceSidebar(props: DesignerWorkspaceSidebarProps) {
               className={`relative h-16 w-16 flex-col gap-1 rounded-lg border text-[11px] transition ${
                 isActive
                   ? "border-yellow-400 bg-yellow-400 text-slate-950 shadow-[0_0_0_3px_rgba(250,204,21,0.16)] hover:bg-yellow-400"
-                  : "border-transparent text-slate-300 hover:border-slate-700 hover:bg-slate-900 hover:text-yellow-200"
+                  : "border-transparent text-slate-500 hover:border-slate-300 hover:bg-slate-200/70 hover:text-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:bg-slate-800 dark:hover:text-yellow-200"
               }`}
               aria-current={isActive ? "page" : undefined}
               onClick={() => props.onPanelChange(panel.id)}

--- a/components/designer/help-dialog.tsx
+++ b/components/designer/help-dialog.tsx
@@ -12,8 +12,7 @@ const LEGEND = [
   { color: "bg-red-500", label: "Bleed — art must extend here; trimmed off" },
   { color: "bg-gray-400", label: "Trim — the finished cut edge" },
   { color: "bg-emerald-500", label: "Safe — keep important content inside" },
-  { color: "bg-blue-500", label: "Address zone — keep clear (USPS)" },
-  { color: "bg-amber-500", label: "Indicia — postage area, keep clear" },
+  { color: "bg-amber-500", label: "Stamp / Indicia — placeable postage areas; keep other elements clear" },
 ]
 
 export function HelpDialogBody() {

--- a/components/designer/mail-spec.ts
+++ b/components/designer/mail-spec.ts
@@ -34,8 +34,6 @@ export interface SpecRects {
   trim: RectPx
   bleed: RectPx
   safe: RectPx
-  address: RectPx
-  indicia: RectPx
 }
 
 export interface MailFormat {
@@ -127,17 +125,6 @@ export function printSizePx(
   return { width: c.width * PRINT_SCALE, height: c.height * PRINT_SCALE }
 }
 
-function clampZone(
-  preferredWIn: number,
-  preferredHIn: number,
-  trimWIn: number,
-  trimHIn: number,
-): { w: number; h: number } {
-  const w = Math.max(0.5, Math.min(preferredWIn, trimWIn - 1)) * DESIGN_PPI
-  const h = Math.max(0.5, Math.min(preferredHIn, trimHIn - 1)) * DESIGN_PPI
-  return { w, h }
-}
-
 export function specRectsPx(
   formatId: MailFormatId,
   orientation: MailOrientation,
@@ -148,17 +135,11 @@ export function specRectsPx(
   const H = hIn * DESIGN_PPI
   const bleed = fmt.bleedIn * DESIGN_PPI
   const safe = fmt.safeIn * DESIGN_PPI
-  const margin = 0.25 * DESIGN_PPI
-
-  const addr = clampZone(fmt.isLetter ? 4 : 3.75, fmt.isLetter ? 1.5 : 1.75, wIn, hIn)
-  const ind = clampZone(1.5, 0.75, wIn, hIn)
 
   return {
     trim: { x: 0, y: 0, w: W, h: H },
     bleed: { x: -bleed, y: -bleed, w: W + bleed * 2, h: H + bleed * 2 },
     safe: { x: safe, y: safe, w: W - safe * 2, h: H - safe * 2 },
-    address: { x: W - margin - addr.w, y: H - margin - addr.h, w: addr.w, h: addr.h },
-    indicia: { x: W - margin - ind.w, y: margin, w: ind.w, h: ind.h },
   }
 }
 

--- a/components/designer/module-definitions.ts
+++ b/components/designer/module-definitions.ts
@@ -1,11 +1,14 @@
 import {
   ImageIcon,
+  Mail,
   MessageSquareText,
   QrCode,
   RectangleHorizontal,
+  Stamp,
   Table2,
   Type,
 } from "lucide-react"
+import { POSTAGE_DEFAULTS } from "@/components/designer/postage"
 import type { DesignElement, DesignerElementType } from "@/types/designer"
 
 export type DesignerModule = {
@@ -23,6 +26,8 @@ export const DESIGNER_MODULES: DesignerModule[] = [
   { id: "shape", label: "Graphic", description: "Shape, line, or callout", type: "graphic", icon: RectangleHorizontal },
   { id: "qr", label: "QR Code", description: "Scannable URL or text code", type: "qr", icon: QrCode },
   { id: "table", label: "Table", description: "Editable rows and columns", type: "table", icon: Table2 },
+  { id: "stamp", label: "Stamp Area", description: "Postage stamp area — keep clear", type: "postage", icon: Stamp },
+  { id: "indicia", label: "Indicia Area", description: "Permit imprint area — keep clear", type: "postage", icon: Mail },
 ]
 
 export function createElementId(prefix: string) {
@@ -121,6 +126,23 @@ export function createModuleElement(
       y: position.y,
       width: 320,
       height: 120,
+      zIndex,
+    }
+  }
+
+  if (moduleId === "stamp" || moduleId === "indicia") {
+    const kind = moduleId
+    const d = POSTAGE_DEFAULTS[kind]
+    return {
+      id,
+      name: kind === "stamp" ? "Stamp Area" : "Indicia Area",
+      type: "postage",
+      kind,
+      x: position.x,
+      y: position.y,
+      width: d.width,
+      height: d.height,
+      locked: true,
       zIndex,
     }
   }

--- a/components/designer/modules-panel.tsx
+++ b/components/designer/modules-panel.tsx
@@ -4,10 +4,12 @@ import type { DesignerModule } from "@/components/designer/module-definitions"
 import { DESIGNER_MODULES } from "@/components/designer/module-definitions"
 import { setDragPayload } from "@/components/designer/dnd"
 import { AssetPicker } from "@/components/designer/asset-picker"
-import type { DesignerImageAsset, Tool } from "@/types/designer"
+import { availablePostageKinds, type PostageKind } from "@/components/designer/postage"
+import type { DesignElement, DesignerImageAsset, Tool } from "@/types/designer"
 
 interface ModulesPanelProps {
   activeTool: Tool
+  elements: DesignElement[]
   onSelectTool: (tool: Tool) => void
   onAddModule: (moduleId: string) => void
   savedImages: DesignerImageAsset[]
@@ -25,6 +27,7 @@ const toolFilters: { id: Tool; label: string; modules: string[] }[] = [
   { id: "graphics", label: "Graphics", modules: ["shape"] },
   { id: "qr-codes", label: "QR Codes", modules: ["qr"] },
   { id: "tables", label: "Tables", modules: ["table"] },
+  { id: "postage", label: "Postage", modules: ["stamp", "indicia"] },
 ]
 
 function ModuleCard({ item, onAddModule }: { item: DesignerModule; onAddModule: (moduleId: string) => void }) {
@@ -52,6 +55,7 @@ function ModuleCard({ item, onAddModule }: { item: DesignerModule; onAddModule: 
 
 export function ModulesPanel({
   activeTool,
+  elements,
   onSelectTool,
   onAddModule,
   savedImages,
@@ -63,7 +67,13 @@ export function ModulesPanel({
   onInsertImage,
 }: ModulesPanelProps) {
   const activeFilter = toolFilters.find((tool) => tool.id === activeTool) ?? toolFilters[0]
-  const visibleModules = DESIGNER_MODULES.filter((item) => activeFilter.modules.includes(item.id))
+  const postageAvailable = availablePostageKinds(elements)
+  const visibleModules = DESIGNER_MODULES.filter((item) => {
+    if (!activeFilter.modules.includes(item.id)) return false
+    if (activeFilter.id === "postage") return postageAvailable.includes(item.id as PostageKind)
+    return true
+  })
+  const postageFull = activeFilter.id === "postage" && visibleModules.length === 0
 
   return (
     <div className="space-y-4 bg-card p-4 text-foreground">
@@ -89,13 +99,7 @@ export function ModulesPanel({
           </button>
         ))}
       </div>
-      {activeFilter.id !== "images" ? (
-        <div className="space-y-2">
-          {visibleModules.map((item) => (
-            <ModuleCard key={item.id} item={item} onAddModule={onAddModule} />
-          ))}
-        </div>
-      ) : (
+      {activeFilter.id === "images" ? (
         <AssetPicker
           mode={imagePickerMode}
           savedImages={savedImages}
@@ -105,6 +109,16 @@ export function ModulesPanel({
           onUploadImage={onUploadImage}
           onPick={onInsertImage}
         />
+      ) : postageFull ? (
+        <div className="rounded-lg border border-border bg-muted/40 p-3 text-xs leading-5 text-muted-foreground">
+          A postage area is already on this page. A mailpiece uses one stamp <em>or</em> indicia — delete the existing one to switch.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {visibleModules.map((item) => (
+            <ModuleCard key={item.id} item={item} onAddModule={onAddModule} />
+          ))}
+        </div>
       )}
     </div>
   )

--- a/components/designer/postage.ts
+++ b/components/designer/postage.ts
@@ -30,6 +30,24 @@ export function isPostageType(type: string): boolean {
   return type === "postage"
 }
 
+type IdBox = Box & { id?: string; type: string }
+
+/**
+ * Keep-clear rule: a postage box and any OTHER element are mutually exclusive in
+ * space. A move/drop of `moving` to `candidate` is a violation if it would
+ * overlap an element of the opposite class (postage vs non-postage). Same-class
+ * overlaps are fine (normal elements may overlap; postage is a singleton, so
+ * postage-vs-postage never occurs).
+ */
+export function violatesKeepClear(moving: { id?: string; type: string }, candidate: Box, others: IdBox[]): boolean {
+  const movingIsPostage = isPostageType(moving.type)
+  return others.some((o) => {
+    if (o.id && moving.id && o.id === moving.id) return false
+    if (isPostageType(o.type) === movingIsPostage) return false
+    return rectsOverlap(candidate, o)
+  })
+}
+
 /**
  * Singleton + mutual exclusion: a mailpiece uses stamp OR indicia, at most one
  * total. Returns the kinds that may still be ADDED given current elements.

--- a/components/designer/postage.ts
+++ b/components/designer/postage.ts
@@ -1,0 +1,46 @@
+import type { CanvasSize, DesignElement } from "@/types/designer"
+
+export type PostageKind = "stamp" | "indicia"
+
+export interface PostageDefault {
+  label: string
+  width: number
+  height: number
+}
+
+// Approximate footprints in the design space (inches × DESIGN_PPI=100).
+// Stamp ≈ 0.96×1.08in; indicia permit imprint ≈ 1.5×0.75in. Documented
+// approximations isolated here; ops validates against the USPS DMM before print.
+export const POSTAGE_DEFAULTS: Record<PostageKind, PostageDefault> = {
+  stamp: { label: "STAMP", width: 96, height: 108 },
+  indicia: { label: "INDICIA", width: 150, height: 75 },
+}
+
+export const POSTAGE_KINDS: PostageKind[] = ["stamp", "indicia"]
+
+type Box = Pick<DesignElement, "x" | "y" | "width" | "height">
+
+/** Pure: do two axis-aligned boxes overlap with positive area? (edge-touch = false) */
+export function rectsOverlap(a: Box, b: Box): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y
+}
+
+/** True for stamp/indicia postage elements. */
+export function isPostageType(type: string): boolean {
+  return type === "postage"
+}
+
+/**
+ * Singleton + mutual exclusion: a mailpiece uses stamp OR indicia, at most one
+ * total. Returns the kinds that may still be ADDED given current elements.
+ */
+export function availablePostageKinds(elements: { type: string }[]): PostageKind[] {
+  return elements.some((e) => isPostageType(e.type)) ? [] : [...POSTAGE_KINDS]
+}
+
+/** Default placement for a new postage element: top-right, inside a small margin. */
+export function defaultPostagePosition(kind: PostageKind, canvas: CanvasSize): { x: number; y: number } {
+  const d = POSTAGE_DEFAULTS[kind]
+  const margin = 24
+  return { x: Math.max(margin, canvas.width - margin - d.width), y: margin }
+}

--- a/components/designer/preflight/preflight-rules.ts
+++ b/components/designer/preflight/preflight-rules.ts
@@ -39,9 +39,6 @@ function inside(inner: RectPx, outer: RectPx): boolean {
     inner.y + inner.h <= outer.y + outer.h
   )
 }
-function overlaps(a: RectPx, b: RectPx): boolean {
-  return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
-}
 
 export function runPreflight(elements: DesignElement[], ctx: PreflightContext): PreflightIssue[] {
   const issues: PreflightIssue[] = []
@@ -84,9 +81,6 @@ export function runPreflight(elements: DesignElement[], ctx: PreflightContext): 
       const r = box(el)
       if (!inside(r, ctx.specRects.safe)) {
         add("warning", "out-of-safe", `${label} is outside the safe area and may be trimmed.`)
-      }
-      if (overlaps(r, ctx.specRects.address) || overlaps(r, ctx.specRects.indicia)) {
-        add("error", "clear-zone", `${label} overlaps the USPS address/indicia clear zone.`)
       }
     }
   }

--- a/components/designer/ui/confirm-dialog.tsx
+++ b/components/designer/ui/confirm-dialog.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+/** Reusable confirm dialog for consequential designer actions (e.g. deleting a
+ *  postage area). Controlled via `open`; resolves through onConfirm/onCancel. */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel?: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onCancel}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className={destructive ? "bg-destructive text-destructive-foreground hover:bg-destructive/90" : undefined}
+          >
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/components/designer/ui/designer-tokens.ts
+++ b/components/designer/ui/designer-tokens.ts
@@ -7,18 +7,19 @@
 //
 // Import these instead of hardcoding slate-9xx so a surface is never dark-only again.
 
-/** Surfaces. `rail` is intentionally fixed-dark in both themes (brand). */
+/** Surfaces. `rail` is a theme-aware, softly-tinted chrome surface (brand identity
+ *  carried by the yellow active chip, not a dark-everywhere fill). */
 export const designerSurface = {
   panel: "bg-card text-card-foreground",
   inset: "bg-muted/50",
-  rail: "bg-slate-950 text-slate-300",
+  rail: "bg-gradient-to-b from-slate-50 to-slate-100 text-slate-600 dark:from-slate-900 dark:to-slate-950 dark:text-slate-300",
   canvas: "bg-muted/60 dark:bg-slate-900",
 } as const
 
 export const designerBorder = {
   base: "border-border",
   subtle: "border-border/60",
-  rail: "border-slate-800",
+  rail: "border-slate-200 dark:border-slate-800",
 } as const
 
 export const designerText = {

--- a/docs/DESIGNER_POSTAGE_BUILD_REPORT.md
+++ b/docs/DESIGNER_POSTAGE_BUILD_REPORT.md
@@ -1,0 +1,46 @@
+# Designer Postage Areas — Build Report (P0–P5)
+
+Branch `feature/designer-postage-areas` (off merged `main` @ 32d9f8b), built autonomously via `/goal`
+against `docs/DESIGNER_POSTAGE_SPEC.md`. UI-only (no DB schema changes). Status: **all phases
+implemented and gate-verified; awaiting owner visual review before PR.**
+
+## What shipped, by phase
+- **P1 — Model + remove Address.** New `postage` element type (`kind: stamp|indicia`) + pure
+  `components/designer/postage.ts` (defaults, rectsOverlap, availablePostageKinds, defaultPostagePosition,
+  violatesKeepClear) with mocha tests. Removed the Address Area entirely and de-zoned Indicia: dropped
+  address+indicia from SpecRects/specRectsPx, the print-overlay boxes, the obsolete preflight clear-zone
+  check, and the help legend. (`1836bb0`)
+- **P2 — Modules + singleton.** "Postage" tool tab with Stamp Area + Indicia Area cards; createModuleElement
+  builds a locked-by-default labelled element; render-element draws the keep-clear box (STAMP/INDICIA).
+  availablePostageKinds gates the cards: once one exists, both hide and a singleton/mutual-exclusion note
+  shows (one stamp OR indicia per piece). (`942417d`)
+- **P3 — Keep-clear.** No other element may overlap a postage box: onDragStop/onResizeStop revert on
+  violation; onDrop rejects dropping onto a postage box. Labels + locked-default confirmed. (`5cc2c2d`)
+- **P4 — Guarded delete.** Reusable ConfirmDialog; every delete path (keyboard, layers, canvas) routes
+  through a guard — postage deletes require explicit confirmation; others delete immediately. (`002c90d`)
+
+## Requirements coverage (all owner-confirmed)
+- Address Area removed ✓ · Stamp + Indicia movable elements, separate sizes ✓ · addable from Module menu ✓
+- Guarded delete (confirm dialog) ✓ · Singleton + mutually exclusive (one stamp OR indicia) ✓
+- Locked by default ✓ · On-canvas STAMP/INDICIA labels ✓ · Keep-clear / no-overlay ✓
+- Out of scope (declined): USPS clearance preflight, snap-to-position.
+
+## Verification (evidence)
+- `npm run typecheck:ui` → 0
+- `npx mocha` → **193 passing** (incl. postage helpers: overlap, singleton, keep-clear, placement)
+- `npm run build` → **exit 0**; `/design/customize` builds (66.6 kB / 278 kB)
+- All changed source files ≤ 350 LOC (max: page.tsx 301, canvas-area 297)
+- chrome-devtools, verified:
+  - Place Stamp → labelled locked box; Postage tab then shows singleton note, no cards (light + dark)
+    — `docs/temp/p2-postage-{light,dark}.png`
+  - Place Indicia (dark) → renders; with one placed, both cards hidden (mutual exclusion both ways)
+    — `docs/temp/p5-indicia-dark.png`
+  - Keep-clear: dragging COMPANY NAME onto the STAMP snaps it back (no overlap) — `docs/temp/p3-keepclear-light.png`
+  - Guarded delete: Delete opens "Remove this postage area?"; Cancel keeps, Remove deletes — `docs/temp/p4-delete-guard-light.png`
+- Repo-wide `npm run lint` intentionally NOT a gate (~743 pre-existing errors); per-file eslint clean on all changed files.
+
+## Notes for review
+- Postage sizes are documented approximations (stamp 96×108, indicia 150×75 at DESIGN_PPI=100); ops should
+  validate against the USPS DMM before production print (isolated in `postage.ts`).
+- Objective gates are green; subjective polish is the owner's call — stops here for visual review.
+  Suggested next step: `/git-workflow-planning:finish` (PR) once approved.

--- a/docs/DESIGNER_POSTAGE_SPEC.md
+++ b/docs/DESIGNER_POSTAGE_SPEC.md
@@ -1,0 +1,69 @@
+# DESIGNER_POSTAGE_SPEC — autonomous build spec (for /goal)
+
+GOAL: Build the Designer Postage Areas feature on branch `feature/designer-postage-areas`. Full
+scope + rationale: `.claude/plans/feature-designer-postage-areas.md` (read it first). This spec adds
+the transcript-provable EXIT CRITERIA the goal evaluator needs.
+
+## CURRENT STATE (do not rediscover)
+- Worktree off `main` @ 32d9f8b — already contains the merged designer UI design system
+  (`components/designer/ui/` tokens + primitives, theme-coherent inspector/panels/canvas). REUSE it.
+- Single-element selection model. Stamp/Indicia are postal-compliance elements: separate, different
+  default sizes; the Address Area must be removed.
+- Gates: `npm run typecheck:ui`, `npx mocha <file>`, `npm run build`, per-file `npx eslint`.
+  Repo-wide `npm run lint` is NOT a gate (~743 pre-existing errors).
+- Designer is auth-gated; cookie auth is shared across localhost ports.
+
+## HARD CONSTRAINTS (hold at every checkpoint)
+1. UI-only. **NO DB schema changes / NO migrations / no `supabase db reset`.** If one seems needed,
+   STOP and write `docs/temp/designer-postage-BLOCKED.md`.
+2. Stay in THIS worktree; never run git against the main `yls/` tree. Dev server on a **free,
+   non-3010 port**.
+3. Every changed/added source file **≤350 LOC**; TS strict, no `any`; reuse `components/designer/ui/`
+   primitives; no FPD.
+4. Invoke **frontend-design** before UI. Verify in **chrome-devtools** (never Playwright), light+dark.
+
+## PHASES (in order; each ends with a checkpoint commit)
+
+### P0 — Setup
+EXIT: `git rev-parse --show-toplevel` = the postage worktree AND `git branch --show-current` =
+`feature/designer-postage-areas`; `/git-workflow-planning:start feature designer-postage-areas` run;
+dev server up on a free non-3010 port (port shown); frontend-design announced.
+
+### P1 — Model + remove Address + pure helpers
+EXIT:
+- A postage element model exists (one type with `kind: 'stamp'|'indicia'` OR two types) with default
+  sizes + `locked` default; show via `git status`/diff.
+- The **Address Area is gone**: a grep for the address zone/box shows it removed from `mail-spec.ts`
+  / `print-overlay.tsx` (no placeable address box remains).
+- Pure helpers with co-located mocha tests in `tests/designer/`: (a) **overlap/intersection** test
+  (does a box intersect a postage box), (b) **singleton/mutual-exclusion** availability (given
+  current elements, which of stamp/indicia may be added). `npx mocha` → passing (show output).
+- `npm run typecheck:ui` 0; per-file eslint 0. Checkpoint 1 commit (show `git log -1`).
+
+### P2 — Module menu (add Stamp / Indicia)
+EXIT: Module menu shows **Stamp Area** + **Indicia Area** entries; availability enforces singleton +
+mutual exclusivity (once one exists, the others are hidden/disabled — verify in CDT). Adding places a
+locked, labelled element. typecheck:ui 0; eslint 0; CDT both-theme screenshot; checkpoint 2.
+
+### P3 — Canvas behavior (keep-clear + labels + locked)
+EXIT: on-canvas **"STAMP"/"INDICIA" labels** render; new elements start **locked**; **keep-clear**:
+dropping a module onto, or dragging an element over, a postage box is rejected/blocked (the other
+element cannot overlap) — demonstrated in CDT (attempt overlap → element does not end up on top).
+typecheck:ui 0; eslint 0; CDT both-theme screenshots; checkpoint 3.
+
+### P4 — Guarded delete
+EXIT: deleting a Stamp/Indicia element opens a **confirmation dialog requiring explicit approval**
+(shared confirm component); cancel keeps it, confirm removes it — both shown in CDT. Non-postage
+elements delete without the dialog. typecheck:ui 0; eslint 0; checkpoint 4.
+
+### P5 — Polish + verification
+EXIT: full CDT pass in BOTH themes (place stamp, place indicia blocked while stamp exists or vice
+versa, move, overlap-rejected, delete-guard); `npm run build` exit 0; `npm run typecheck:ui` 0; all
+designer mocha tests pass; every changed source file ≤350 LOC (prove by line count); checkpoint 5.
+
+## DEFINITION OF DONE
+All P0–P5 EXIT CRITERIA met + evidenced in the transcript, in order; build 0, typecheck:ui 0, mocha
+green at P5; all changed files ≤350 LOC (shown); CDT light+dark evidence per phase; checkpoints
+1–5 committed. THEN STOP and request owner visual review before `/git-workflow-planning:finish`. Do
+NOT self-certify subjective polish; an honest report of which criteria passed/failed also satisfies
+the goal. Do not disable eslint/type/test gates to pass.

--- a/tests/designer/mail-spec.test.ts
+++ b/tests/designer/mail-spec.test.ts
@@ -51,19 +51,13 @@ describe('canvasSizePx / printSizePx', () => {
 })
 
 describe('specRectsPx', () => {
-  it('produces trim/bleed/safe with correct insets, and address+indicia inside trim', () => {
+  it('produces trim/bleed/safe with correct insets', () => {
     const r = specRectsPx('postcard_4x6', 'portrait') // 400 x 600 trim
     assert.deepEqual(r.trim, { x: 0, y: 0, w: 400, h: 600 })
     // bleed 0.125in = 12.5px outside the trim on every side
     assert.deepEqual(r.bleed, { x: -12.5, y: -12.5, w: 425, h: 625 })
     // safe 0.125in = 12.5px inside
     assert.deepEqual(r.safe, { x: 12.5, y: 12.5, w: 375, h: 575 })
-    for (const zone of [r.address, r.indicia]) {
-      assert.ok(zone.w > 0 && zone.h > 0, 'zone has positive size')
-      assert.ok(zone.x >= 0 && zone.y >= 0, 'zone inside trim (origin)')
-      assert.ok(zone.x + zone.w <= r.trim.w, 'zone within trim width')
-      assert.ok(zone.y + zone.h <= r.trim.h, 'zone within trim height')
-    }
   })
 
   it('letter uses a wider safe margin than postcards', () => {

--- a/tests/designer/postage.test.ts
+++ b/tests/designer/postage.test.ts
@@ -4,6 +4,7 @@ import {
   rectsOverlap,
   availablePostageKinds,
   defaultPostagePosition,
+  violatesKeepClear,
   POSTAGE_KINDS,
   POSTAGE_DEFAULTS,
 } from '../../components/designer/postage'
@@ -27,6 +28,24 @@ describe('availablePostageKinds (singleton + mutual exclusion)', () => {
   })
   it('none available once a stamp exists', () => {
     assert.deepEqual(availablePostageKinds([{ type: 'postage' }, { type: 'text' }]), [])
+  })
+})
+
+describe('violatesKeepClear', () => {
+  const stamp = { id: 'p', type: 'postage', x: 0, y: 0, width: 100, height: 100 }
+  const text = { id: 't', type: 'text', x: 0, y: 0, width: 100, height: 100 }
+  it('blocks a non-postage element moving onto a postage box', () => {
+    assert.equal(violatesKeepClear(text, { x: 50, y: 50, width: 100, height: 100 }, [stamp]), true)
+  })
+  it('blocks a postage element moving onto a non-postage element', () => {
+    assert.equal(violatesKeepClear(stamp, { x: 50, y: 50, width: 100, height: 100 }, [text]), true)
+  })
+  it('allows non-postage overlapping non-postage (normal stacking)', () => {
+    const other = { id: 'o', type: 'graphic', x: 0, y: 0, width: 100, height: 100 }
+    assert.equal(violatesKeepClear(text, { x: 50, y: 50, width: 100, height: 100 }, [other]), false)
+  })
+  it('ignores self and non-overlapping boxes', () => {
+    assert.equal(violatesKeepClear(text, { x: 300, y: 300, width: 10, height: 10 }, [stamp, text]), false)
   })
 })
 

--- a/tests/designer/postage.test.ts
+++ b/tests/designer/postage.test.ts
@@ -1,0 +1,39 @@
+import { describe, it } from 'mocha'
+import { strict as assert } from 'assert'
+import {
+  rectsOverlap,
+  availablePostageKinds,
+  defaultPostagePosition,
+  POSTAGE_KINDS,
+  POSTAGE_DEFAULTS,
+} from '../../components/designer/postage'
+
+describe('rectsOverlap', () => {
+  const a = { x: 0, y: 0, width: 100, height: 100 }
+  it('true when boxes intersect', () => {
+    assert.equal(rectsOverlap(a, { x: 50, y: 50, width: 100, height: 100 }), true)
+  })
+  it('false when edge-touching (no positive area)', () => {
+    assert.equal(rectsOverlap(a, { x: 100, y: 0, width: 50, height: 50 }), false)
+  })
+  it('false when fully separated', () => {
+    assert.equal(rectsOverlap(a, { x: 200, y: 200, width: 10, height: 10 }), false)
+  })
+})
+
+describe('availablePostageKinds (singleton + mutual exclusion)', () => {
+  it('both available when no postage placed', () => {
+    assert.deepEqual(availablePostageKinds([{ type: 'text' }]), POSTAGE_KINDS)
+  })
+  it('none available once a stamp exists', () => {
+    assert.deepEqual(availablePostageKinds([{ type: 'postage' }, { type: 'text' }]), [])
+  })
+})
+
+describe('defaultPostagePosition', () => {
+  it('places top-right inside the margin', () => {
+    const pos = defaultPostagePosition('indicia', { width: 600, height: 900 })
+    assert.equal(pos.y, 24)
+    assert.equal(pos.x, 600 - 24 - POSTAGE_DEFAULTS.indicia.width)
+  })
+})

--- a/tests/designer/preflight-rules.test.ts
+++ b/tests/designer/preflight-rules.test.ts
@@ -25,21 +25,10 @@ describe('runPreflight', () => {
     assert.ok(issues.some((i) => i.elementId === 'small' && i.severity === 'error' && i.rule === 'tiny-font'))
   })
 
-  it('flags content outside the safe area and inside the address clear zone', () => {
+  it('flags content outside the safe area', () => {
     const outside = el({ id: 'oob', type: 'graphic', x: 0, y: 0, width: 5, height: 5, shape: 'rectangle', fill: '#000' } as Partial<DesignElement> & { id: string; type: 'graphic' })
-    const inAddr = el({
-      id: 'addr',
-      type: 'graphic',
-      x: spec.address.x + 2,
-      y: spec.address.y + 2,
-      width: 10,
-      height: 10,
-      shape: 'rectangle',
-      fill: '#000',
-    } as Partial<DesignElement> & { id: string; type: 'graphic' })
-    const issues = runPreflight([outside, inAddr], { specRects: spec })
+    const issues = runPreflight([outside], { specRects: spec })
     assert.ok(issues.some((i) => i.elementId === 'oob' && i.rule === 'out-of-safe'))
-    assert.ok(issues.some((i) => i.elementId === 'addr' && i.rule === 'clear-zone' && i.severity === 'error'))
   })
 
   it('flags a low-resolution image (natural px < required at 300 DPI)', () => {

--- a/types/designer.ts
+++ b/types/designer.ts
@@ -3,7 +3,7 @@ import type { MailFormatId } from "@/components/designer/mail-spec"
 // Phase 12: dead `"colors" | "background"` Tool members removed (the only
 // consumer, legacy tools-sidebar.tsx, is archived). Page backgrounds live in
 // the `"background"` WorkspacePanel below.
-export type Tool = "text" | "images" | "graphics" | "qr-codes" | "tables"
+export type Tool = "text" | "images" | "graphics" | "qr-codes" | "tables" | "postage"
 export type WorkspacePanel = "modules" | "layers" | "inspector" | "preflight" | "background"
 export type DesignerPage = "front" | "back"
 export type DesignerOrientation = "portrait" | "landscape"

--- a/types/designer.ts
+++ b/types/designer.ts
@@ -7,7 +7,7 @@ export type Tool = "text" | "images" | "graphics" | "qr-codes" | "tables"
 export type WorkspacePanel = "modules" | "layers" | "inspector" | "preflight" | "background"
 export type DesignerPage = "front" | "back"
 export type DesignerOrientation = "portrait" | "landscape"
-export type DesignerElementType = "text" | "image" | "graphic" | "qr" | "table"
+export type DesignerElementType = "text" | "image" | "graphic" | "qr" | "table" | "postage"
 export type DesignerMode = "select" | "pan"
 
 export interface CanvasSize {
@@ -77,12 +77,20 @@ export interface TableDesignElement extends BaseDesignElement {
   headerRow?: boolean
 }
 
+// Postage compliance element (stamp or indicia). Movable, locked by default,
+// keep-clear (no other element may overlap it). Singleton + mutually exclusive.
+export interface PostageDesignElement extends BaseDesignElement {
+  type: "postage"
+  kind: "stamp" | "indicia"
+}
+
 export type DesignElement =
   | TextDesignElement
   | ImageDesignElement
   | GraphicDesignElement
   | QrDesignElement
   | TableDesignElement
+  | PostageDesignElement
 
 export interface PageBackgroundImage {
   assetId?: string


### PR DESCRIPTION
Promote develop to main. Includes the Stamp/Indicia postage-areas feature (PR #22) and the designer chrome polish (theme-aware rail, streamlined header). Verified: typecheck:ui 0, mocha 193 passing, build exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added movable Stamp and Indicia postage areas that can be positioned on the canvas and are locked by default.
  * Enforced mutual exclusivity—only one postage area allowed per design.
  * Added protection against accidental deletion with confirmation dialog.
  * Elements cannot overlap postage areas; overlap attempts are rejected.

* **Improvements**
  * Updated template and format selectors to use dropdown components.
  * Removed fixed Address Area overlay.
  * Updated help dialog legend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->